### PR TITLE
Create tag build to push to launchpad

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,16 +47,16 @@ jobs:
           # remove v prefix from version
           DEB_VERSION="${RELEASE_VERSION#v}"
           # replace - with ~ in DEB_VERSION
-          DEB_VERSION="${DEB_VERSION/-/\~}"
+          # DEB_VERSION="${DEB_VERSION/-/\~}"
 
           echo -e "$DEB_VERSION" > share/github-backup-utils/version
           echo "DEB_VERSION=\"${DEB_VERSION}\"" >> $GITHUB_ENV
           
           cat > new_change << EOF
-          github-backup-utils (${DEB_VERSION}) UNRELEASED; urgency=medium
+          github-backup-utils (${DEB_VERSION}); urgency=medium
             * built in CI
           
-           -- github-actions <github@github.com> $(date +'%a, %d %b %Y %T %z')
+           -- github-actions <github@github.com>  $(date +'%a, %d %b %Y %T %z')
            
           EOF
           

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,10 +71,10 @@ jobs:
           cd "$GITHUB_WORKSPACE"
 
           make dist
-          make deb
+          # make deb
 
           # this makes the .changes file for the ppa upload
-          # debuild -S -sa -uc -us -v${DEB_VERSION}
+          debuild -S -sa -uc -us -v${DEB_VERSION}
 
           ls -lha ../github-backup-utils*
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
           # make deb
 
           # this makes the .changes file for the ppa upload
-          debuild -S -sa -uc -us -v${DEB_VERSION}
+          debuild -uc -us -v${DEB_VERSION}
 
           ls -lha ../github-backup-utils*
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
           DEB_VERSION="${DEB_VERSION/-/\~}"
 
           echo -e "$DEB_VERSION" > share/github-backup-utils/version
-          echo "DEB_VERSION=\"${DEB_VERSION}\"" >> $GITHUB_ENV
+          echo "DEB_VERSION=${DEB_VERSION}" >> $GITHUB_ENV
           
           cat > new_change << EOF
           github-backup-utils (${DEB_VERSION}) UNRELEASED; urgency=medium

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
 
           ls -lha ../github-backup-utils*
 
-          debsign -k${{ steps.gpg.outputs.keyid }} ../github-backup-utils_${DEB_VERSION}_source.changes
+          debsign -k${{ steps.gpg.outputs.keyid }} ../github-backup-utils_${DEB_VERSION}_amd64.changes
 
       - name: Creating PPA configuration
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,11 +44,19 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE"
 
-          echo -e "$RELEASE_VERSION" > share/github-backup-utils/version
+
+          # remove v prefix from version
+          DEB_VERSION=${RELEASE_VERSION#v}
+          # replace - with ~ in DEB_VERSION
+          DEB_VERSION=${DEB_VERSION//-/~}
+
+          echo -e "$DEB_VERSION" > share/github-backup-utils/version
+          echo "DEB_VERSION=${DEB_VERSION}" >> $GITHUB_ENV
           
           cat > new_change << EOF
-          github-backup-utils (${RELEASE_VERSION}) UNRELEASED; urgency=medium
+          github-backup-utils (${DEB_VERSION}) UNRELEASED; urgency=medium
             * built in CI
+          
            -- github-actions $(date +'%a, %d %b %Y %T %z')
            
           EOF
@@ -63,12 +71,11 @@ jobs:
           cd "$GITHUB_WORKSPACE"
 
           make dist
-          make deb
-
-          ls -lha
 
           # this makes the .changes file for the ppa upload
-          debuild -S -sa -v ${RELEASE_VERSION}
+          debuild -S -sa -v ${DEB_VERSION}
+
+          ls -lha
 
       - name: Creating PPA configuration
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,7 @@ jobs:
           # make deb
 
           # this makes the .changes file for the ppa upload
-          debuild -uc -us -v${DEB_VERSION}
+          debuild -b -uc -us -v${DEB_VERSION}
 
           ls -lha ../github-backup-utils*
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,4 +91,4 @@ jobs:
       - name: Publishing to PPA
         run: |
           cd $GITHUB_WORKSPACE
-          dput reddit-ppa ../github-backup-utils_${DEB_VERSION}_source.changes
+          dput --unchecked reddit-ppa ../github-backup-utils_${DEB_VERSION}_source.changes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
           echo "DEB_VERSION=${DEB_VERSION}" >> $GITHUB_ENV
           
           cat > new_change << EOF
-          github-backup-utils (${DEB_VERSION}) UNRELEASED; urgency=medium
+          github-backup-utils (${DEB_VERSION}) bionic; urgency=medium
             * built in CI
           
            -- github-actions <github@github.com>  $(date +'%a, %d %b %Y %T %z')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,7 @@ jobs:
 
           ls -lha ../github-backup-utils*
 
-          debsign -k ${{ steps.gpg.outputs.email }} ../github-backup-utils_${DEB_VERSION}_source.changes
+          # debsign -k ${{ steps.gpg.outputs.email }} ../github-backup-utils_${DEB_VERSION}_source.changes
 
       - name: Creating PPA configuration
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,16 +45,18 @@ jobs:
           cd "$GITHUB_WORKSPACE"
 
           echo -e "$RELEASE_VERSION" > share/github-backup-utils/version
-
-          echo -e "github-backup-utils ($RELEASE_VERSION); urgency=medium\n" >> debian/changelog
-          echo -e "  * built in CI\n" >> debian/changelog
-          echo " -- github-actions  $(date +'%a, %d %b %Y %T %z')" >> debian/changelog
+          
+          cat > new_change << EOF
+          github-backup-utils (${RELEASE_VERSION}); urgency=medium
+            * built in CI
+           -- github-actions $(date +'%a, %d %b %Y %T %z')
+           
+          EOF
+          
+          # prepend the new stuff above to the changelog
+          cat new_change | cat - debian/changelog > debian/changelog
 
           cat debian/changelog
-          
-      - name: Building Github Backup Utils
-        run: |
-          cat share/github-backup-utils/version
 
       - name: Building Github Backup Utils
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
           # make deb
 
           # this makes the .changes file for the ppa upload
-          debuild -uc -us -v${DEB_VERSION}
+          debuild -uc -us -v${DEB_VERSION} -k${{ secrets.GPG_KEY_ID }}
 
           ls -lha ../github-backup-utils*
 
@@ -93,4 +93,4 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           echo -e "dput --unchecked reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes"
-          dput --unchecked reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes
+          dput reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,5 +93,5 @@ jobs:
       - name: Publishing to PPA
         run: |
           cd $GITHUB_WORKSPACE
-          echo -e "dput reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes"
-          dput reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes
+          echo -e "dput --unchecked reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes"
+          dput --unchecked reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,14 +44,13 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE"
 
-
           # remove v prefix from version
-          DEB_VERSION=${RELEASE_VERSION#v}
+          DEB_VERSION="${RELEASE_VERSION#v}"
           # replace - with ~ in DEB_VERSION
-          DEB_VERSION=${DEB_VERSION//-/~}
+          DEB_VERSION="${DEB_VERSION/-/\~}"
 
           echo -e "$DEB_VERSION" > share/github-backup-utils/version
-          echo "DEB_VERSION=${DEB_VERSION}" >> $GITHUB_ENV
+          echo "DEB_VERSION=\"${DEB_VERSION}\"" >> $GITHUB_ENV
           
           cat > new_change << EOF
           github-backup-utils (${DEB_VERSION}) UNRELEASED; urgency=medium

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,11 +75,11 @@ jobs:
           # make deb
 
           # this makes the .changes file for the ppa upload
-          debuild -uc -us -v${DEB_VERSION} -k${{ secrets.GPG_KEY_ID }}
+          debuild -uc -us -v${DEB_VERSION} -k${{ steps.gpg.outputs.keyid }} 
 
           ls -lha ../github-backup-utils*
 
-          # debsign -k ${{ steps.gpg.outputs.email }} ../github-backup-utils_${DEB_VERSION}_source.changes
+          debsign -k${{ steps.gpg.outputs.keyid }} ../github-backup-utils_${DEB_VERSION}_source.changes
 
       - name: Creating PPA configuration
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,10 @@ jobs:
           echo " -- github-actions  $(date +'%a, %d %b %Y %T %z')" >> debian/changelog
 
           cat debian/changelog
+          
+      - name: Building Github Backup Utils
+        run: |
+          cat share/github-backup-utils/version
 
       - name: Building Github Backup Utils
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
           # this makes the .changes file for the ppa upload
           debuild -S -sa -v${DEB_VERSION}
 
-          ls -lha
+          ls -lha ../github-backup-utils*
 
       - name: Creating PPA configuration
         run: |
@@ -88,5 +88,4 @@ jobs:
       - name: Publishing to PPA
         run: |
           cd $GITHUB_WORKSPACE
-          ls -lha
-          # dput reddit-ppa ../automysqlbackup_$(echo $GITHUB_REF | grep -oP "([0-9].*)" )_source.changes
+          dput reddit-ppa ../github-backup-utils_${DEB_VERSION}_source.changes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,7 @@ jobs:
 
           ls -lha ../github-backup-utils*
 
-          debsign -k ${{ steps.gpg.outputs.keyid }} ../github-backup-utils_${DEB_VERSION}_source.changes
+          debsign -k ${{ steps.gpg.outputs.email }} ../github-backup-utils_${DEB_VERSION}_source.changes
 
       - name: Creating PPA configuration
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,8 @@ jobs:
           # prepend the new stuff above to the changelog
           cat new_change | cat - debian/changelog > /tmp/new_changelog && mv /tmp/new_changelog debian/changelog
 
+          sed -i "s/@@VERSION@@/${RELEASE_VERSION}/g" debian/control
+
           cat debian/changelog
 
       - name: Building Github Backup Utils

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
 
           ls -lha ../github-backup-utils*
 
-          # debsign -k${{ steps.gpg.outputs.keyid }} ../github-backup-utils_${DEB_VERSION}_source.changes
+          debsign -k${{ steps.gpg.outputs.keyid }} ../github-backup-utils_${DEB_VERSION}_source.changes
 
       - name: Creating PPA configuration
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Trust key
         run: |
-          gpg --no-tty --command-fd 0 --edit-key ${{ secrets.GPG_KEY_ID }} <<EOTRUST
+          gpg --no-tty --command-fd 0 --edit-key ${{ steps.gpg.outputs.keyid }} <<EOTRUST
           trust
           5
           y
@@ -79,7 +79,7 @@ jobs:
 
           ls -lha ../github-backup-utils*
 
-          debsign -k${{ steps.gpg.outputs.keyid }} ../github-backup-utils_${DEB_VERSION}_source.changes
+          # debsign -k${{ steps.gpg.outputs.keyid }} ../github-backup-utils_${DEB_VERSION}_source.changes
 
       - name: Creating PPA configuration
         run: |
@@ -93,5 +93,5 @@ jobs:
       - name: Publishing to PPA
         run: |
           cd $GITHUB_WORKSPACE
-          echo -e "dput --unchecked reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes"
+          echo -e "dput reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes"
           dput reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,11 @@ jobs:
           echo "$GITHUB_ENV"
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v4
+        uses: crazy-max/ghaction-import-gpg@v5
         id: gpg
         with:
           gpg_private_key: ${{ secrets.GPG_SIGNING_KEY }}
+          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
 
       - name: Trust key
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,11 +75,11 @@ jobs:
           # make deb
 
           # this makes the .changes file for the ppa upload
-          debuild -b -uc -us -v${DEB_VERSION}
+          debuild -S -sa -v${DEB_VERSION} -k${{ steps.gpg.outputs.keyid }}
 
           ls -lha ../github-backup-utils*
 
-          debsign -k${{ steps.gpg.outputs.keyid }} ../github-backup-utils_${DEB_VERSION}_amd64.changes
+          # debsign -k${{ steps.gpg.outputs.keyid }} ../github-backup-utils_${DEB_VERSION}_source.changes
 
       - name: Creating PPA configuration
         run: |
@@ -93,5 +93,5 @@ jobs:
       - name: Publishing to PPA
         run: |
           cd $GITHUB_WORKSPACE
-          echo -e "dput reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes"
-          dput reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes
+          echo -e "dput reddit-ppa ../github-backup-utils_${DEB_VERSION}_source.changes"
+          dput reddit-ppa ../github-backup-utils_${DEB_VERSION}_source.changes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,9 +71,10 @@ jobs:
           cd "$GITHUB_WORKSPACE"
 
           make dist
+          make deb
 
           # this makes the .changes file for the ppa upload
-          debuild -S -sa -uc -us -v${DEB_VERSION}
+          # debuild -S -sa -uc -us -v${DEB_VERSION}
 
           ls -lha ../github-backup-utils*
 
@@ -91,4 +92,4 @@ jobs:
       - name: Publishing to PPA
         run: |
           cd $GITHUB_WORKSPACE
-          dput --unchecked reddit-ppa ../github-backup-utils_${DEB_VERSION}_source.changes
+          echo -e "dput --unchecked reddit-ppa ../github-backup-utils_${DEB_VERSION}_source.changes"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
           EOF
           
           # prepend the new stuff above to the changelog
-          cat new_change | cat - debian/changelog > debian/changelog
+          cat new_change | cat - debian/changelog > /tmp/new_changelog && mv /tmp/new_changelog debian/changelog
 
           cat debian/changelog
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,78 @@
+---
+name: Deploy to launchpad.net
+
+on:
+  push:
+    tags:
+      - v*.*.*-reddit*
+
+jobs:
+  build:
+    name: Packaging software
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set env
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "$GITHUB_ENV"
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_SIGNING_KEY }}
+
+      - name: Trust key
+        run: |
+          gpg --no-tty --command-fd 0 --edit-key ${{ secrets.GPG_KEY_ID }} <<EOTRUST
+          trust
+          5
+          y
+          quit
+          EOTRUST
+
+      - name: List keys
+        run: gpg -K
+
+      - name: Run install commands
+        run: sudo apt-get install dput devscripts debhelper moreutils
+
+      - name: Creating version
+        run: |
+          cd "$GITHUB_WORKSPACE"
+
+          echo -e "$RELEASE_VERSION" > share/github-backup-utils/version
+
+          echo -e "github-backup-utils ($RELEASE_VERSION); urgency=medium\n" >> debian/changelog
+          echo -e "  * built in CI\n" >> debian/changelog
+          echo " -- github-actions  $(date +'%a, %d %b %Y %T %z')" >> debian/changelog
+
+          cat debian/changelog
+
+      - name: Building Github Backup Utils
+        run: |
+          cd $GITHUB_WORKSPACE
+
+          make dist
+          make deb
+
+          # this makes the .changes file for the ppa upload
+          debuild -S -sa
+
+      - name: Creating PPA configuration
+        run: |
+          echo "[reddit-ppa]" >> $HOME/.dput.cf
+          echo "fqdn = ppa.launchpad.net" >> $HOME/.dput.cf
+          echo "method = ftp" >> $HOME/.dput.cf
+          echo "incoming = ${{ secrets.PPA_INCOMING }}" >> $HOME/.dput.cf
+          echo "login = anonymous" >> $HOME/.dput.cf
+          echo "allow_unsigned_uploads = 0" >> $HOME/.dput.cf
+
+      - name: Publishing to PPA
+        run: |
+          cd $GITHUB_WORKSPACE
+          ls -lha
+          # dput reddit-ppa ../automysqlbackup_$(echo $GITHUB_REF | grep -oP "([0-9].*)" )_source.changes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,7 @@ jobs:
           github-backup-utils (${DEB_VERSION}) UNRELEASED; urgency=medium
             * built in CI
           
-           -- github-actions $(date +'%a, %d %b %Y %T %z')
+           -- github-actions <github@github.com> $(date +'%a, %d %b %Y %T %z')
            
           EOF
           
@@ -72,7 +72,7 @@ jobs:
           make dist
 
           # this makes the .changes file for the ppa upload
-          debuild -S -sa -v ${DEB_VERSION}
+          debuild -S -sa -v${DEB_VERSION}
 
           ls -lha
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ jobs:
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v4
+        id: gpg
         with:
           gpg_private_key: ${{ secrets.GPG_SIGNING_KEY }}
 
@@ -76,7 +77,7 @@ jobs:
 
           ls -lha ../github-backup-utils*
 
-          debsign -k ${{ secrets.GPG_KEY_ID }} ../github-backup-utils_${DEB_VERSION}_source.changes
+          debsign -k ${{ steps.gpg.outputs.keyid }} ../github-backup-utils_${DEB_VERSION}_source.changes
 
       - name: Creating PPA configuration
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         run: gpg -K
 
       - name: Run install commands
-        run: sudo apt-get install dput devscripts debhelper moreutils
+        run: sudo apt-get install -y dput devscripts debhelper moreutils help2man
 
       - name: Creating version
         run: |
@@ -47,7 +47,7 @@ jobs:
           echo -e "$RELEASE_VERSION" > share/github-backup-utils/version
           
           cat > new_change << EOF
-          github-backup-utils (${RELEASE_VERSION}); urgency=medium
+          github-backup-utils (${RELEASE_VERSION}) UNRELEASED; urgency=medium
             * built in CI
            -- github-actions $(date +'%a, %d %b %Y %T %z')
            
@@ -56,19 +56,19 @@ jobs:
           # prepend the new stuff above to the changelog
           cat new_change | cat - debian/changelog > /tmp/new_changelog && mv /tmp/new_changelog debian/changelog
 
-          sed -i "s/@@VERSION@@/${RELEASE_VERSION}/g" debian/control
-
           cat debian/changelog
 
       - name: Building Github Backup Utils
         run: |
-          cd $GITHUB_WORKSPACE
+          cd "$GITHUB_WORKSPACE"
 
           make dist
           make deb
 
+          ls -lha
+
           # this makes the .changes file for the ppa upload
-          debuild -S -sa
+          debuild -S -sa -v ${RELEASE_VERSION}
 
       - name: Creating PPA configuration
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
           echo "DEB_VERSION=\"${DEB_VERSION}\"" >> $GITHUB_ENV
           
           cat > new_change << EOF
-          github-backup-utils (${DEB_VERSION}); urgency=medium
+          github-backup-utils (${DEB_VERSION}) UNRELEASED; urgency=medium
             * built in CI
           
            -- github-actions <github@github.com>  $(date +'%a, %d %b %Y %T %z')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,4 +92,5 @@ jobs:
       - name: Publishing to PPA
         run: |
           cd $GITHUB_WORKSPACE
-          echo -e "dput --unchecked reddit-ppa ../github-backup-utils_${DEB_VERSION}_source.changes"
+          echo -e "dput --unchecked reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes"
+          dput --unchecked reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
           # remove v prefix from version
           DEB_VERSION="${RELEASE_VERSION#v}"
           # replace - with ~ in DEB_VERSION
-          # DEB_VERSION="${DEB_VERSION/-/\~}"
+          DEB_VERSION="${DEB_VERSION/-/\~}"
 
           echo -e "$DEB_VERSION" > share/github-backup-utils/version
           echo "DEB_VERSION=\"${DEB_VERSION}\"" >> $GITHUB_ENV

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,7 @@ jobs:
           # make deb
 
           # this makes the .changes file for the ppa upload
-          debuild -uc -us -v${DEB_VERSION} -k${{ steps.gpg.outputs.keyid }} 
+          debuild -uc -us -v${DEB_VERSION}
 
           ls -lha ../github-backup-utils*
 
@@ -93,5 +93,5 @@ jobs:
       - name: Publishing to PPA
         run: |
           cd $GITHUB_WORKSPACE
-          echo -e "dput --unchecked reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes"
-          dput --unchecked reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes
+          echo -e "dput reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes"
+          dput reddit-ppa ../github-backup-utils_${DEB_VERSION}_amd64.changes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
           make dist
 
           # this makes the .changes file for the ppa upload
-          debuild -S -sa -v${DEB_VERSION}
+          debuild -S -sa -uc -us -v${DEB_VERSION}
 
           ls -lha ../github-backup-utils*
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,6 +76,8 @@ jobs:
 
           ls -lha ../github-backup-utils*
 
+          debsign -k ${{ secrets.GPG_KEY_ID }} ../github-backup-utils_${DEB_VERSION}_source.changes
+
       - name: Creating PPA configuration
         run: |
           echo "[reddit-ppa]" >> $HOME/.dput.cf

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,6 @@ Rules-Requires-Root: no
 
 Package: github-backup-utils
 Architecture: all
-Version: @@VERSION@@
 Depends: ${misc:Depends}, rsync (>= 2.6.4), moreutils, jq, git, gawk, pigz
 Description: Backup and recovery utilities for GitHub Enterprise Server
  The backup utilities implement a number of advanced capabilities for backup

--- a/debian/control
+++ b/debian/control
@@ -5,12 +5,13 @@ Priority: optional
 Standards-Version: 4.5.1
 Build-Depends: debhelper (>= 9), gawk, git, moreutils, jq, pigz, rsync (>= 2.6.4), help2man,
 Homepage: https://github.com/github/backup-utils
-Vcs-Git: https://github.com/github/backup-utils.git
-Vcs-Browser: https://github.com/github/backup-utils
+Vcs-Git: https://github.com/reddit/backup-utils.git
+Vcs-Browser: https://github.com/reddit/backup-utils
 Rules-Requires-Root: no
 
 Package: github-backup-utils
 Architecture: all
+Version: @@VERSION@@
 Depends: ${misc:Depends}, rsync (>= 2.6.4), moreutils, jq, git, gawk, pigz
 Description: Backup and recovery utilities for GitHub Enterprise Server
  The backup utilities implement a number of advanced capabilities for backup


### PR DESCRIPTION
Publishes to launchpad. Tested up to actual publish, right now getting rejected because I'm trying to publish `0.0.1~reddit26` and it's rejecting because it's older than the current `3.1.0~reddit1`. Will publish with `3.4.1~reddit1` after merge.

Publish process is just cutting a release/tag, replacing with a `-` instead of the `~` (tags don't allow it, the action will replace it for you) and prefix with a v as we do elsewhere.

key generation docs added to repo